### PR TITLE
Add Mac-compatible run-codemods.sh zsh script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ The full list of completed and planned codemods can be found in [transforms.md](
 
 3. In the root of your project's repo, run codemods with:
 
-```none
-../codemods/run-codemods.bat PACKAGE.JSON_PATH TSCONFIG_PATH SRC_PATH
+    ```none
+    ../codemods/run-codemods.bat PACKAGE.JSON_PATH TSCONFIG_PATH SRC_PATH
 
-PACKAGE.JSON_PATH is the path to your project's package.json
-TSCONFIG_PATH is the path to your project's tsconfig.json file
-SRC_PATH is the path to your src directory
-```
+    PACKAGE.JSON_PATH is the path to your project's package.json
+    TSCONFIG_PATH is the path to your project's tsconfig.json file
+    SRC_PATH is the path to your src directory
+    ```
+
+      If you are on a Mac, replace the bat command line with the following one:
+
+    ```none
+    ../codemods/run-codemods.sh PACKAGE.JSON_PATH TSCONFIG_PATH SRC_PATH
+    ```

--- a/run-codemods.sh
+++ b/run-codemods.sh
@@ -1,0 +1,14 @@
+#! /bin/zsh
+
+# Designed for use on Macs. May work on other *nix OSes.
+
+if [ "$#" -ne 3 ]; then
+  echo Usage:
+  echo "    run-codemods.sh PACKAGE.JSON_PATH TSCONFIG_PATH SRC_PATH"
+  exit 1
+fi
+root="${0:A:h}"
+"${root}/node_modules/.bin/jscodeshift" -t "${root}/transforms/typed-transforms.ts" --extensions=ts,tsx "--tsConfigPath=$2" "$3"
+"${root}/node_modules/.bin/jscodeshift" -t "${root}/transforms/itwin-codemods.ts" --extensions=js,ts --parser=ts "$3"
+"${root}/node_modules/.bin/jscodeshift" -t "${root}/transforms/itwin-codemods.ts" --extensions=jsx,tsx --parser=tsx "$3"
+node "${root}/transforms/update-packagejson.js" "$1"


### PR DESCRIPTION
I needed to run codemods on my Mac to convert our iOS mobile packages. SYNCHRO Field will need to do the same once they are ready to update to iTwin 3. Since the only thing that was OS-specific appeared to be the batch file, I created a Mac-compatible zsh script that is equivalent to the batch file. I also noted this in the README.md.

This is my first iTwin PR. I apologize if I did something wrong.